### PR TITLE
fix: upgraded auth and sdk setup actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
     name: deploy
     steps:
       - name: Deploy to app engine
-        uses: Panenco/gcp-deploy-action@v2
+        uses: Panenco/gcp-deploy-action@v3
         with:
           workload_identity_provider: "{{ secrets.WORKLOAD_IDENTITY_PROVIDER }}"
           service_account: "{{ secrets.SERVICE_ACCOUNT }}"

--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,13 @@ runs:
   steps:
     - id: auth
       name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
+        project_id: ${{inputs.project_id}}
         workload_identity_provider: ${{inputs.workload_identity_provider}}
         service_account: ${{inputs.service_account}}
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v1'
+      uses: 'google-github-actions/setup-gcloud@v2'
     - name: Set credentials
       shell: bash
       run: gcloud auth login --cred-file=${{steps.auth.outputs.credentials_file_path}}


### PR DESCRIPTION
To make the action compatible with Node v20, some actions have been updated.

![Screenshot 2024-03-27 at 15 03 48](https://github.com/Panenco/gcp-deploy-action/assets/71875293/e1faa520-9e82-4be8-a99e-0665e862a416)
