### PR TITLE
chore: upgrade Google GitHub Actions to version 3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,13 +30,13 @@ runs:
   steps:
     - id: auth
       name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         project_id: ${{inputs.project_id}}
         workload_identity_provider: ${{inputs.workload_identity_provider}}
         service_account: ${{inputs.service_account}}
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v3
     - name: Set credentials
       shell: bash
       run: gcloud auth login --cred-file=${{steps.auth.outputs.credentials_file_path}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump in CI deployment tooling; behavior should remain largely the same but could change if `auth@v3`/`setup-gcloud@v3` have breaking defaults or deprecations.
> 
> **Overview**
> Updates the composite action in `action.yml` to authenticate and set up the Google Cloud SDK using `google-github-actions/auth@v3` and `google-github-actions/setup-gcloud@v3` (from v2). Also normalizes the Cloud SDK step name/quoting while keeping the deploy and version-cleanup commands unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a16063cf5cff32666d7e0a2e3a0ba079aebc78db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->